### PR TITLE
Add chat link privacy with noreferrer and noopener

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -3030,9 +3030,9 @@ function create_hotlinks($message){
 	$message=preg_replace_callback('/<<([^<>]+)>>/u',
 		function ($matches){
 			if(strpos($matches[1], '://')===false){
-				return "<a href=\"http://$matches[1]\" target=\"_blank\">$matches[1]</a>";
+				return "<a href=\"http://$matches[1]\" target=\"_blank\" rel=\"noreferrer noopener\">$matches[1]</a>";
 			}else{
-				return "<a href=\"$matches[1]\" target=\"_blank\">$matches[1]</a>";
+				return "<a href=\"$matches[1]\" target=\"_blank\" rel=\"noreferrer noopener\">$matches[1]</a>";
 			}
 		}
 	, $message);


### PR DESCRIPTION
**noreferrer** tells the browser to not send the referer header, so the site opened does not know where are you coming from.
**noopener** prevents the opened site to be able to control the main window.