### PR TITLE
Disable Guests private messages settings

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -2063,7 +2063,7 @@ function send_post(string $rejected=''): void
 	if(isset($_POST['multi'])){
 		echo hidden('multi', 'on');
 	}
-	echo '<table><tr><td><table><tr id="firstline"><td> ' . $U['status'] . ' ' .style_this(htmlspecialchars($U['nickname']), $U['style']).'</td><td>:</td>';
+	echo '<table><tr><td><table><tr id="firstline"><td> ' . style_this(htmlspecialchars($U['nickname']), $U['style']) . '</td><td>:</td>';
 	if(isset($_POST['multi'])){
 		echo "<td><textarea name=\"message\" rows=\"3\" cols=\"40\" style=\"$U[style]\" autofocus>$rejected</textarea></td>";
 	}else{


### PR DESCRIPTION
Disable Guests private messages
![Screenshot from 2025-06-23 15-28-44](https://github.com/user-attachments/assets/51cc5085-5de1-4440-9c13-fe77359d4468)

![image](https://github.com/user-attachments/assets/d13ae82f-6794-4b2e-b784-dc10f9ba1ba4)

This PR offers a basic check to the Guest System for the PM Enable and Disable, it also adds the system a option to send a message back to the user via PM.


This PR is in reply to https://github.com/DanWin/le-chat-php/issues/122

Also updated the copyright from 22 to 25
